### PR TITLE
feat: add ipv6 allocation option

### DIFF
--- a/easytier-web/frontend-lib/src/components/Config.vue
+++ b/easytier-web/frontend-lib/src/components/Config.vue
@@ -298,6 +298,21 @@ const portForwardProtocolOptions = ref(["tcp","udp"]);
                 </div>
               </div>
 
+              <div class="flex flex-row gap-x-9 flex-wrap ">
+                <div class="flex flex-col gap-2 grow">
+                  <label>{{ t('enable_ipv6_distribute') }}</label>
+                  <ToggleButton v-model="curNetwork.enable_ipv6_distribute" on-icon="pi pi-check" off-icon="pi pi-times"
+                    :on-label="t('off_text')" :off-label="t('on_text')" class="w-48" />
+                  <div v-if="curNetwork.enable_ipv6_distribute" class="items-center flex flex-row gap-x-4">
+                    <div class="flex flex-row gap-x-9 flex-wrap w-full">
+                      <div class="flex flex-col gap-2 basis-8/12 grow">
+                        <InputText v-model="curNetwork.ipv6_distribute_prefix" :placeholder="t('ipv6_distribute_prefix')" />
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
               <div class="flex flex-row gap-x-9 flex-wrap">
                 <div class="flex flex-col gap-2 grow p-fluid">
                   <label for="listener_urls">{{ t('listener_urls') }}</label>

--- a/easytier-web/frontend-lib/src/locales/cn.yaml
+++ b/easytier-web/frontend-lib/src/locales/cn.yaml
@@ -13,6 +13,8 @@ proxy_cidrs: 子网代理CIDR
 enable_vpn_portal: 启用VPN门户
 vpn_portal_listen_port: 监听端口
 vpn_portal_client_network: 客户端子网
+enable_ipv6_distribute: 下发IPv6地址
+ipv6_distribute_prefix: 下发IPv6前缀
 dev_name: TUN接口名称
 advanced_settings: 高级设置
 basic_settings: 基础设置

--- a/easytier-web/frontend-lib/src/locales/en.yaml
+++ b/easytier-web/frontend-lib/src/locales/en.yaml
@@ -13,6 +13,8 @@ proxy_cidrs: Subnet Proxy CIDRs
 enable_vpn_portal: Enable VPN Portal
 vpn_portal_listen_port: VPN Portal Listen Port
 vpn_portal_client_network: Client Sub Network
+enable_ipv6_distribute: Deliver IPv6 Addresses
+ipv6_distribute_prefix: IPv6 Prefix
 dev_name: TUN interface name
 advanced_settings: Advanced Settings
 basic_settings: Basic Settings

--- a/easytier-web/frontend-lib/src/types/network.ts
+++ b/easytier-web/frontend-lib/src/types/network.ts
@@ -28,6 +28,9 @@ export interface NetworkConfig {
   vpn_portal_client_network_addr: string
   vpn_portal_client_network_len: number
 
+  enable_ipv6_distribute: boolean
+  ipv6_distribute_prefix: string
+
   advanced_settings: boolean
 
   listener_urls: string[]
@@ -96,6 +99,9 @@ export function DEFAULT_NETWORK_CONFIG(): NetworkConfig {
     vpn_portal_listen_port: 22022,
     vpn_portal_client_network_addr: '',
     vpn_portal_client_network_len: 24,
+
+    enable_ipv6_distribute: false,
+    ipv6_distribute_prefix: '',
 
     advanced_settings: false,
 

--- a/easytier/src/common/config.rs
+++ b/easytier/src/common/config.rs
@@ -143,6 +143,12 @@ pub trait ConfigLoader: Send + Sync {
     fn get_ipv6(&self) -> Option<cidr::Ipv6Inet>;
     fn set_ipv6(&self, addr: Option<cidr::Ipv6Inet>);
 
+    fn get_enable_ipv6_assign(&self) -> bool;
+    fn set_enable_ipv6_assign(&self, enable: bool);
+
+    fn get_ipv6_assign_prefix(&self) -> Option<cidr::Ipv6Cidr>;
+    fn set_ipv6_assign_prefix(&self, prefix: Option<cidr::Ipv6Cidr>);
+
     fn get_dhcp(&self) -> bool;
     fn set_dhcp(&self, dhcp: bool);
 
@@ -400,6 +406,9 @@ struct Config {
 
     vpn_portal_config: Option<VpnPortalConfig>,
 
+    enable_ipv6_assign: Option<bool>,
+    ipv6_assign_prefix: Option<String>,
+
     routes: Option<Vec<cidr::Ipv4Cidr>>,
 
     socks5_proxy: Option<url::Url>,
@@ -552,6 +561,30 @@ impl ConfigLoader for TomlConfigLoader {
 
     fn set_ipv6(&self, addr: Option<cidr::Ipv6Inet>) {
         self.config.lock().unwrap().ipv6 = addr.map(|addr| addr.to_string());
+    }
+
+    fn get_enable_ipv6_assign(&self) -> bool {
+        self.config
+            .lock()
+            .unwrap()
+            .enable_ipv6_assign
+            .unwrap_or_default()
+    }
+
+    fn set_enable_ipv6_assign(&self, enable: bool) {
+        self.config.lock().unwrap().enable_ipv6_assign = Some(enable);
+    }
+
+    fn get_ipv6_assign_prefix(&self) -> Option<cidr::Ipv6Cidr> {
+        let locked_config = self.config.lock().unwrap();
+        locked_config
+            .ipv6_assign_prefix
+            .as_ref()
+            .and_then(|s| s.parse().ok())
+    }
+
+    fn set_ipv6_assign_prefix(&self, prefix: Option<cidr::Ipv6Cidr>) {
+        self.config.lock().unwrap().ipv6_assign_prefix = prefix.map(|p| p.to_string());
     }
 
     fn get_dhcp(&self) -> bool {

--- a/easytier/src/common/global_ctx.rs
+++ b/easytier/src/common/global_ctx.rs
@@ -453,6 +453,8 @@ impl GlobalCtx {
                     #[cfg(target_os = "windows")]
                     {
                         use std::process::Command;
+                        // Install a /128 route and publish it so the host advertises
+                        // reachability for the delegated address.
                         let _ = Command::new("netsh")
                             .args([
                                 "interface",
@@ -461,10 +463,20 @@ impl GlobalCtx {
                                 "route",
                                 &format!("{}/128", addr_str),
                                 &dev,
+                                "publish=yes",
                             ])
                             .status();
+                        // Enable forwarding on the interface so Windows will answer
+                        // Neighbor Discovery requests for the published address.
                         let _ = Command::new("netsh")
-                            .args(["interface", "ipv6", "add", "proxy", &addr_str, &dev])
+                            .args([
+                                "interface",
+                                "ipv6",
+                                "set",
+                                "interface",
+                                &dev,
+                                "forwarding=enabled",
+                            ])
                             .status();
                     }
 

--- a/easytier/src/common/global_ctx.rs
+++ b/easytier/src/common/global_ctx.rs
@@ -18,6 +18,7 @@ use super::{
     config::{ConfigLoader, Flags},
     netns::NetNS,
     network::IPCollector,
+    ipv6_allocator::Ipv6Allocator,
     stun::{StunInfoCollector, StunInfoCollectorTrait},
     PeerId,
 };
@@ -89,6 +90,8 @@ pub struct GlobalCtx {
     stats_manager: Arc<StatsManager>,
 
     acl_filter: Arc<AclFilter>,
+
+    ipv6_allocator: Option<Arc<Ipv6Allocator>>,
 }
 
 impl std::fmt::Debug for GlobalCtx {
@@ -140,6 +143,14 @@ impl GlobalCtx {
             ..Default::default()
         };
 
+        let ipv6_allocator = if config_fs.get_enable_ipv6_assign() {
+            config_fs
+                .get_ipv6_assign_prefix()
+                .map(|p| Arc::new(Ipv6Allocator::new(p)))
+        } else {
+            None
+        };
+
         GlobalCtx {
             inst_name: config_fs.get_inst_name(),
             id,
@@ -175,6 +186,8 @@ impl GlobalCtx {
             stats_manager: Arc::new(StatsManager::new()),
 
             acl_filter: Arc::new(AclFilter::new()),
+
+            ipv6_allocator,
         }
     }
 
@@ -407,6 +420,12 @@ impl GlobalCtx {
             .and_then(|acl| acl.acl_v1)
             .and_then(|acl_v1| acl_v1.group)
             .map_or_else(Vec::new, |group| group.declares.to_vec())
+    }
+
+    pub fn alloc_ipv6_for_peer(&self, peer_id: PeerId) -> Option<std::net::Ipv6Addr> {
+        self.ipv6_allocator
+            .as_ref()
+            .and_then(|a| a.allocate(peer_id))
     }
 }
 

--- a/easytier/src/common/ipv6_allocator.rs
+++ b/easytier/src/common/ipv6_allocator.rs
@@ -1,0 +1,52 @@
+use std::net::Ipv6Addr;
+use std::sync::Mutex;
+
+use cidr::Ipv6Cidr;
+use dashmap::DashMap;
+
+use crate::common::PeerId;
+
+#[derive(Debug)]
+pub struct Ipv6Allocator {
+    prefix: Ipv6Cidr,
+    next: Mutex<u128>,
+    assigned: DashMap<PeerId, Ipv6Addr>,
+}
+
+impl Ipv6Allocator {
+    pub fn new(prefix: Ipv6Cidr) -> Self {
+        Self {
+            prefix,
+            next: Mutex::new(1),
+            assigned: DashMap::new(),
+        }
+    }
+
+    pub fn allocate(&self, peer_id: PeerId) -> Option<Ipv6Addr> {
+        if let Some(addr) = self.assigned.get(&peer_id) {
+            return Some(*addr);
+        }
+        let host_bits = 128 - self.prefix.network_length() as u8;
+        let max_hosts: u128 = 1u128 << host_bits;
+        let mut idx = self.next.lock().unwrap();
+        if *idx >= max_hosts {
+            return None;
+        }
+        let base: u128 = self.prefix.first_address().into();
+        let addr = Ipv6Addr::from(base + *idx);
+        *idx += 1;
+        self.assigned.insert(peer_id, addr);
+        #[cfg(target_os = "linux")]
+        {
+            use std::process::Command;
+            let addr_str = addr.to_string();
+            let _ = Command::new("ip")
+                .args(["-6", "route", "replace", &format!("{}/128", addr_str), "dev", "lo"])
+                .status();
+            let _ = Command::new("ip")
+                .args(["-6", "neigh", "add", "proxy", &addr_str, "dev", "lo"])
+                .status();
+        }
+        Some(addr)
+    }
+}

--- a/easytier/src/common/ipv6_allocator.rs
+++ b/easytier/src/common/ipv6_allocator.rs
@@ -36,17 +36,6 @@ impl Ipv6Allocator {
         let addr = Ipv6Addr::from(base + *idx);
         *idx += 1;
         self.assigned.insert(peer_id, addr);
-        #[cfg(target_os = "linux")]
-        {
-            use std::process::Command;
-            let addr_str = addr.to_string();
-            let _ = Command::new("ip")
-                .args(["-6", "route", "replace", &format!("{}/128", addr_str), "dev", "lo"])
-                .status();
-            let _ = Command::new("ip")
-                .args(["-6", "neigh", "add", "proxy", &addr_str, "dev", "lo"])
-                .status();
-        }
         Some(addr)
     }
 }

--- a/easytier/src/common/mod.rs
+++ b/easytier/src/common/mod.rs
@@ -19,6 +19,7 @@ pub mod dns;
 pub mod error;
 pub mod global_ctx;
 pub mod ifcfg;
+pub mod ipv6_allocator;
 pub mod netns;
 pub mod network;
 pub mod scoped_task;

--- a/easytier/src/proto/web.proto
+++ b/easytier/src/proto/web.proto
@@ -75,6 +75,9 @@ message NetworkConfig {
     repeated PortForwardConfig port_forwards = 48;
 
     optional bool disable_sym_hole_punching = 49;
+
+    optional bool enable_ipv6_distribute = 50;
+    optional string ipv6_distribute_prefix = 51;
 }
 
 message PortForwardConfig {


### PR DESCRIPTION
## Summary
- add option to distribute IPv6 addresses through GUI/web
- implement backend IPv6 allocator and config support

## Testing
- `cargo test` *(incomplete: long-running test, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68bf91ece938832e9de14297fd790bdf